### PR TITLE
[FEAT] 인증/인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'com.auth0:java-jwt:4.4.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/farmdora/farmdora/auth/config/SecurityConfig.java
+++ b/src/main/java/com/farmdora/farmdora/auth/config/SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.farmdora.farmdora.auth.config;
+
+import com.farmdora.farmdora.auth.filter.JwtAuthorizationFilter;
+import com.farmdora.farmdora.auth.service.LoginService;
+import com.farmdora.farmdora.auth.util.JwtUtil;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.headers(headers -> headers.frameOptions(FrameOptionsConfig::disable))
+            .cors(cors -> cors.configurationSource(configurationSource()))
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable);
+
+        http.logout(logout -> logout
+                .logoutUrl("/api/logout")
+        );
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource configurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://127.0.0.1:3000"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With"));
+        configuration.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
+        configuration.addExposedHeader("Authorization");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/controller/LoginController.java
+++ b/src/main/java/com/farmdora/farmdora/auth/controller/LoginController.java
@@ -1,0 +1,84 @@
+package com.farmdora.farmdora.auth.controller;
+
+import com.farmdora.farmdora.auth.dto.JoinRequestDto;
+import com.farmdora.farmdora.auth.dto.JwtProperties;
+import com.farmdora.farmdora.auth.dto.LoginRequestDto;
+import com.farmdora.farmdora.auth.dto.LoginUser;
+import com.farmdora.farmdora.auth.dto.TokenResponseDto;
+import com.farmdora.farmdora.auth.exception.RefreshTokenNotExistsException;
+import com.farmdora.farmdora.auth.service.LoginService;
+import com.farmdora.farmdora.auth.util.CookieUtil;
+import com.farmdora.farmdora.common.response.HttpResponse;
+import com.farmdora.farmdora.common.response.SuccessMessage;
+import com.farmdora.farmdora.entity.User;
+import com.farmdora.farmdora.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class LoginController {
+
+    private final LoginService loginService;
+    private final UserRepository userRepository;
+    private final JwtProperties jwtProperties;
+
+    @PostMapping("/join")
+    public ResponseEntity<?> join(@RequestBody JoinRequestDto joinRequestDto) {
+        loginService.join(joinRequestDto);
+        return ResponseEntity.ok().body(new HttpResponse(HttpStatus.OK, SuccessMessage.WRITE_SUCCESS.getMessage(), null));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequestDto loginRequestDto) {
+        TokenResponseDto tokens = loginService.login(loginRequestDto);
+        ResponseCookie refreshCookie = CookieUtil.createResponseCookie(tokens.getRefreshToken(), jwtProperties.getRefreshExpirationTime());
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                .body(new HttpResponse(HttpStatus.OK, SuccessMessage.LOGIN_SUCCESS.getMessage(), tokens.getAccessToken()));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(@CookieValue(name = "refreshToken", required = false) String refreshCookie,
+                                     HttpServletResponse response) {
+        if (refreshCookie == null || refreshCookie.isBlank()) {
+            CookieUtil.clearRefreshCookie(response);
+            throw new RefreshTokenNotExistsException();
+        }
+
+        TokenResponseDto tokens = loginService.reissueTokens(refreshCookie);
+        ResponseCookie newRefreshCookie = CookieUtil.createResponseCookie(tokens.getRefreshToken(), jwtProperties.getRefreshExpirationTime());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, newRefreshCookie.toString())
+                .body(new HttpResponse(HttpStatus.OK, SuccessMessage.CREATE_TOKENS.getMessage(), tokens.getAccessToken()));
+    }
+
+    @GetMapping("/test")
+    public ResponseEntity<?> test(@AuthenticationPrincipal LoginUser loginUser) {
+
+        log.info("### test loginUser: {}", loginUser.toString());
+
+        Optional<User> user = userRepository.findById(loginUser.getId());
+
+        log.info("### 로그인 정보 : {}", user.get());
+
+        return ResponseEntity.ok().body(user.get());
+    }
+
+}

--- a/src/main/java/com/farmdora/farmdora/auth/dto/JoinRequestDto.java
+++ b/src/main/java/com/farmdora/farmdora/auth/dto/JoinRequestDto.java
@@ -1,0 +1,29 @@
+package com.farmdora.farmdora.auth.dto;
+
+import com.farmdora.farmdora.entity.Gender;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class JoinRequestDto {
+    private String username;
+    private String password;
+    private String name;
+    private String email;
+    private String addr;
+    private String addrDetail;
+    private String zipCode;
+    private LocalDate birth;
+    private Gender gender;
+    private String phone;
+}

--- a/src/main/java/com/farmdora/farmdora/auth/dto/JwtConstants.java
+++ b/src/main/java/com/farmdora/farmdora/auth/dto/JwtConstants.java
@@ -1,0 +1,11 @@
+package com.farmdora.farmdora.auth.dto;
+
+public final class JwtConstants {
+    private JwtConstants() {};
+
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    public static final String CLAIM_SUBJECT = "token";
+    public static final String CLAIM_ID = "id";
+    public static final String CLAIM_ROLE = "role";
+}

--- a/src/main/java/com/farmdora/farmdora/auth/dto/JwtProperties.java
+++ b/src/main/java/com/farmdora/farmdora/auth/dto/JwtProperties.java
@@ -1,0 +1,16 @@
+package com.farmdora.farmdora.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(value = "jwt")
+public class JwtProperties {
+    private String secret;
+    private long expirationTime;
+    private long refreshExpirationTime;
+}

--- a/src/main/java/com/farmdora/farmdora/auth/dto/LoginRequestDto.java
+++ b/src/main/java/com/farmdora/farmdora/auth/dto/LoginRequestDto.java
@@ -1,0 +1,19 @@
+package com.farmdora.farmdora.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequestDto {
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/farmdora/farmdora/auth/dto/LoginUser.java
+++ b/src/main/java/com/farmdora/farmdora/auth/dto/LoginUser.java
@@ -1,0 +1,41 @@
+package com.farmdora.farmdora.auth.dto;
+
+import java.util.Collection;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Setter
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginUser implements UserDetails {
+
+    private Long id;
+    private String username;
+    private String password;
+    private String role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of((GrantedAuthority) () -> "ROLE_" + role);
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/farmdora/farmdora/auth/dto/TokenResponseDto.java
@@ -1,0 +1,19 @@
+package com.farmdora.farmdora.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/farmdora/farmdora/auth/exception/InvalidJwtTokenException.java
+++ b/src/main/java/com/farmdora/farmdora/auth/exception/InvalidJwtTokenException.java
@@ -1,0 +1,12 @@
+package com.farmdora.farmdora.auth.exception;
+
+import com.farmdora.farmdora.common.error.exception.CustomException;
+import com.farmdora.farmdora.common.error.exception.ErrorMessage;
+import org.springframework.http.HttpStatus;
+
+public class InvalidJwtTokenException extends CustomException {
+
+    public InvalidJwtTokenException() {
+        super(ErrorMessage.INVALID_TOKEN.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/exception/InvalidPasswordException.java
+++ b/src/main/java/com/farmdora/farmdora/auth/exception/InvalidPasswordException.java
@@ -1,0 +1,12 @@
+package com.farmdora.farmdora.auth.exception;
+
+import com.farmdora.farmdora.common.error.exception.CustomException;
+import com.farmdora.farmdora.common.error.exception.ErrorMessage;
+import org.springframework.http.HttpStatus;
+
+public class InvalidPasswordException extends CustomException {
+
+    public InvalidPasswordException() {
+        super(ErrorMessage.INVALID_PASSWORD.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/exception/JwtTokenExpiredException.java
+++ b/src/main/java/com/farmdora/farmdora/auth/exception/JwtTokenExpiredException.java
@@ -1,0 +1,12 @@
+package com.farmdora.farmdora.auth.exception;
+
+import com.farmdora.farmdora.common.error.exception.CustomException;
+import com.farmdora.farmdora.common.error.exception.ErrorMessage;
+import org.springframework.http.HttpStatus;
+
+public class JwtTokenExpiredException extends CustomException {
+
+    public JwtTokenExpiredException() {
+        super(ErrorMessage.TOKEN_EXPIRED.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/exception/RefreshTokenNotExistsException.java
+++ b/src/main/java/com/farmdora/farmdora/auth/exception/RefreshTokenNotExistsException.java
@@ -1,0 +1,12 @@
+package com.farmdora.farmdora.auth.exception;
+
+import com.farmdora.farmdora.common.error.exception.CustomException;
+import com.farmdora.farmdora.common.error.exception.ErrorMessage;
+import org.springframework.http.HttpStatus;
+
+public class RefreshTokenNotExistsException extends CustomException {
+
+    public RefreshTokenNotExistsException() {
+        super(ErrorMessage.EMPTY_TOKEN.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/filter/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/farmdora/farmdora/auth/filter/CustomAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package com.farmdora.farmdora.auth.filter;
+
+import com.farmdora.farmdora.auth.util.AuthenticationResponseUtil;
+import com.farmdora.farmdora.common.error.exception.ErrorMessage;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        log.error("### AccessDeniedHandler : 권한이 없습니다.");
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        AuthenticationResponseUtil.authenticateFail(response, HttpStatus.UNAUTHORIZED, ErrorMessage.UNAUTHORIZED.getMessage());
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/filter/CustomAuthenticationEntrypoint.java
+++ b/src/main/java/com/farmdora/farmdora/auth/filter/CustomAuthenticationEntrypoint.java
@@ -1,0 +1,28 @@
+package com.farmdora.farmdora.auth.filter;
+
+import com.farmdora.farmdora.auth.util.AuthenticationResponseUtil;
+import com.farmdora.farmdora.common.error.exception.ErrorMessage;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntrypoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authenticationException) throws IOException, ServletException {
+
+        log.error("### AuthenticationEntrypoint : 인증이 필요합니다.");
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        AuthenticationResponseUtil.authenticateFail(response, HttpStatus.UNAUTHORIZED, ErrorMessage.UNAUTHORIZED.getMessage());
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/farmdora/farmdora/auth/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,108 @@
+package com.farmdora.farmdora.auth.filter;
+
+import com.farmdora.farmdora.auth.dto.JwtConstants;
+import com.farmdora.farmdora.auth.dto.LoginUser;
+import com.farmdora.farmdora.auth.service.LoginService;
+import com.farmdora.farmdora.auth.util.AuthenticationResponseUtil;
+import com.farmdora.farmdora.auth.util.JwtUtil;
+import com.farmdora.farmdora.common.error.exception.CustomException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final LoginService loginService;
+
+    // 아래 url들은 jwt 토큰 검사를 패스함
+    private static final List<String> WHITELIST = List.of(
+            "/api/auth/login",
+            "/api/auth/join"
+    );
+    private static final AntPathMatcher PATH = new AntPathMatcher();
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        // 브라우저가 CORS 확인할 때 OPTIONS 요청을 먼저 보내는데, 이건 JWT 검증 같은 인증 절차를 거치면 안됨
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+            return true;
+        }
+
+        log.info("### 화이트 리스트를 확인합니다...");
+
+        // true 리턴시 doFilterInternal을 거치지 않음.
+        String uri = request.getRequestURI();
+        return WHITELIST.stream().anyMatch(p -> PATH.match(p, uri));
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req,
+                                    HttpServletResponse res,
+                                    FilterChain chain) throws ServletException, IOException {
+
+        log.info("### JWT를 체크합니다...");
+
+        String token = resolveBearerToken(req);
+        if (!StringUtils.hasText(token)) {
+            chain.doFilter(req, res);
+            return;
+        }
+
+        try {
+            if (StringUtils.hasText(token)) {
+                LoginUser principal = jwtUtil.verify(token);
+                principal = loginService.getLoginUser(principal.getId());
+
+                if (SecurityContextHolder.getContext().getAuthentication() == null) {
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                            principal, null, principal.getAuthorities());
+
+                    SecurityContext context = SecurityContextHolder.createEmptyContext();
+                    context.setAuthentication(authentication);
+                    SecurityContextHolder.setContext(context);
+                }
+            }
+        } catch (CustomException e) {
+            log.error("### 인증도중 에러가 발생했습니다.");
+
+            // JWT토큰이 만료, 유효하지 않은 경우
+            res.setStatus(e.getStatus().value());
+            AuthenticationResponseUtil.authenticateFail(res, e.getStatus(), e.getMessage());
+            return;
+        }
+
+        chain.doFilter(req, res);
+    }
+
+    private String resolveBearerToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (!StringUtils.hasText(header)) {
+            log.error("### Authorization 헤더가 존재하지 않습니다.");
+            return null;
+        }
+
+        if (!header.startsWith(JwtConstants.TOKEN_PREFIX)) {
+            log.error("### Bearer 토큰이 존재하지 않습니다.");
+            return null;
+        }
+        return header.substring(JwtConstants.TOKEN_PREFIX.length()).trim();
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/service/LoginService.java
+++ b/src/main/java/com/farmdora/farmdora/auth/service/LoginService.java
@@ -1,0 +1,18 @@
+package com.farmdora.farmdora.auth.service;
+
+import com.farmdora.farmdora.auth.dto.JoinRequestDto;
+import com.farmdora.farmdora.auth.dto.LoginRequestDto;
+import com.farmdora.farmdora.auth.dto.LoginUser;
+import com.farmdora.farmdora.auth.dto.TokenResponseDto;
+
+public interface LoginService {
+
+    void join(JoinRequestDto joinRequestDto);
+
+    TokenResponseDto login(LoginRequestDto loginRequestDto);
+
+    LoginUser getLoginUser(Long id);
+
+    TokenResponseDto reissueTokens(String refreshToken);
+
+}

--- a/src/main/java/com/farmdora/farmdora/auth/service/impl/LoginServiceImpl.java
+++ b/src/main/java/com/farmdora/farmdora/auth/service/impl/LoginServiceImpl.java
@@ -1,0 +1,102 @@
+package com.farmdora.farmdora.auth.service.impl;
+
+import com.farmdora.farmdora.auth.dto.JoinRequestDto;
+import com.farmdora.farmdora.auth.dto.LoginRequestDto;
+import com.farmdora.farmdora.auth.dto.LoginUser;
+import com.farmdora.farmdora.auth.dto.TokenResponseDto;
+import com.farmdora.farmdora.auth.exception.InvalidPasswordException;
+import com.farmdora.farmdora.auth.service.LoginService;
+import com.farmdora.farmdora.auth.util.JwtUtil;
+import com.farmdora.farmdora.common.error.exception.EntityNotFoundException;
+import com.farmdora.farmdora.entity.Address;
+import com.farmdora.farmdora.entity.Role;
+import com.farmdora.farmdora.entity.User;
+import com.farmdora.farmdora.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LoginServiceImpl implements LoginService {
+
+    private final JwtUtil jwtUtil;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+
+    @Override
+    public void join(JoinRequestDto joinRequestDto) {
+
+        log.info("### 회원가입 정보: {}", joinRequestDto.toString());
+
+        User user = User.builder()
+                .username(joinRequestDto.getUsername())
+                .password(passwordEncoder.encode(joinRequestDto.getPassword()))
+                .name(joinRequestDto.getName())
+                .email(joinRequestDto.getEmail())
+                .address(
+                        Address.builder()
+                                .addr(joinRequestDto.getAddr())
+                                .addrDetail(joinRequestDto.getAddrDetail())
+                                .zipCode(joinRequestDto.getZipCode())
+                                .build()
+                )
+                .birth(joinRequestDto.getBirth())
+                .gender(joinRequestDto.getGender())
+                .phone(joinRequestDto.getPhone())
+                .role(Role.USER)
+                .build();
+
+        userRepository.save(user);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public TokenResponseDto login(LoginRequestDto loginRequestDto) {
+        User user = userRepository.findByUsername(loginRequestDto.getUsername())
+                .orElseThrow(() -> new EntityNotFoundException("User", String.valueOf(loginRequestDto.getUsername())));
+
+        if (!passwordEncoder.matches(loginRequestDto.getPassword(), user.getPassword())) {
+            throw new InvalidPasswordException();
+        }
+
+        Long id = user.getId();
+        Role role = Role.USER;
+        return TokenResponseDto.builder()
+                .accessToken(jwtUtil.createAccessToken(id, role))
+                .refreshToken(jwtUtil.createRefreshToken(id, role))
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public LoginUser getLoginUser(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("User", String.valueOf(id)));
+
+        return LoginUser.builder()
+                .id(id)
+                .username(user.getUsername())
+                .password(user.getPassword())
+                .role(user.getRole().name())
+                .build();
+    }
+
+    @Override
+    public TokenResponseDto reissueTokens(String refreshToken) {
+        LoginUser loginUser = jwtUtil.verify(refreshToken);
+
+        User user = userRepository.findById(loginUser.getId())
+                .orElseThrow(() -> new EntityNotFoundException("User", String.valueOf(loginUser.getId())));
+
+        return TokenResponseDto.builder()
+                .accessToken(jwtUtil.createAccessToken(user.getId(), user.getRole()))
+                .refreshToken(jwtUtil.createRefreshToken(user.getId(), user.getRole()))
+                .build();
+    }
+
+}

--- a/src/main/java/com/farmdora/farmdora/auth/util/AuthenticationResponseUtil.java
+++ b/src/main/java/com/farmdora/farmdora/auth/util/AuthenticationResponseUtil.java
@@ -1,0 +1,22 @@
+package com.farmdora.farmdora.auth.util;
+
+import com.farmdora.farmdora.common.response.HttpResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthenticationResponseUtil {
+
+    public static void authenticateFail(HttpServletResponse response,
+                                        HttpStatus httpStatus,
+                                        String message) throws IOException, ServletException {
+        HttpResponse httpResponse = new HttpResponse(httpStatus, message, null);
+        String responseData = new ObjectMapper().writeValueAsString(httpResponse);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(responseData);
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/util/CookieUtil.java
+++ b/src/main/java/com/farmdora/farmdora/auth/util/CookieUtil.java
@@ -1,0 +1,30 @@
+package com.farmdora.farmdora.auth.util;
+
+import com.farmdora.farmdora.auth.dto.JwtConstants;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CookieUtil {
+
+    public static ResponseCookie createResponseCookie(String refreshToken, Long maxAge) {
+        refreshToken = refreshToken.replace(JwtConstants.TOKEN_PREFIX, "");
+        return ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/api/auth/refresh")
+                .maxAge(Duration.ofMillis(maxAge))
+                .build();
+    }
+
+    public static void clearRefreshCookie(HttpServletResponse response) {
+        ResponseCookie refreshCookie = createResponseCookie("", 0L);
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/util/JwtUtil.java
+++ b/src/main/java/com/farmdora/farmdora/auth/util/JwtUtil.java
@@ -1,0 +1,60 @@
+package com.farmdora.farmdora.auth.util;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.farmdora.farmdora.auth.dto.JwtConstants;
+import com.farmdora.farmdora.auth.dto.JwtProperties;
+import com.farmdora.farmdora.auth.dto.LoginUser;
+import com.farmdora.farmdora.auth.exception.InvalidJwtTokenException;
+import com.farmdora.farmdora.auth.exception.JwtTokenExpiredException;
+import com.farmdora.farmdora.entity.Role;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private final JwtProperties jwtProperties;
+
+    public String createAccessToken(Long userId, Role role) {
+        return createToken(userId, role, jwtProperties.getExpirationTime());
+    }
+
+    public String createRefreshToken(Long userId, Role role) {
+        return createToken(userId, role, jwtProperties.getRefreshExpirationTime());
+    }
+
+    private String createToken(Long id, Role role, long expirationTime) {
+        String jwtToken = JWT.create()
+                .withSubject(JwtConstants.CLAIM_SUBJECT)
+                .withExpiresAt(new Date(System.currentTimeMillis() + expirationTime))
+                .withClaim(JwtConstants.CLAIM_ID, id)
+                .withClaim(JwtConstants.CLAIM_ROLE, role.name())
+                .sign(Algorithm.HMAC512(jwtProperties.getSecret()));
+        return JwtConstants.TOKEN_PREFIX + jwtToken;
+    }
+
+    public LoginUser verify(String token) {
+        try {
+            DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC512(jwtProperties.getSecret()))
+                    .build()
+                    .verify(token);
+
+            return LoginUser.builder()
+                    .id(decodedJWT.getClaim(JwtConstants.CLAIM_ID).asLong())
+                    .role(decodedJWT.getClaim(JwtConstants.CLAIM_ROLE).asString())
+                    .build();
+        } catch (TokenExpiredException e) {
+            throw new JwtTokenExpiredException();
+        } catch (JWTVerificationException e) {
+            throw new InvalidJwtTokenException();
+        }
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/common/error/exception/ErrorMessage.java
+++ b/src/main/java/com/farmdora/farmdora/common/error/exception/ErrorMessage.java
@@ -7,7 +7,14 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorMessage {
     INTERNAL_SERVER_ERROR("서버 에러가 발생했습니다."),
-    ENTITY_NOT_FOUND("데이터가 존재하지 않습니다. ");
+    ENTITY_NOT_FOUND("데이터가 존재하지 않습니다. "),
+
+    TOKEN_EXPIRED("만료된 토큰입니다."),
+    INVALID_TOKEN("유효하지 않은 토큰입니다."),
+    EMPTY_TOKEN("토큰이 존재하지 않습니다."),
+    INVALID_PASSWORD("비밀번호가 일치하지 않습니다."),
+    UNAUTHORIZED("인증이 필요합니다."),
+    FORBIDDEN("권한이 없습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/farmdora/farmdora/common/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/farmdora/farmdora/common/error/handler/GlobalExceptionHandler.java
@@ -22,7 +22,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<?> customExceptionHandler(IllegalArgumentException e) {
-        log.error(e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new HttpResponse(HttpStatus.INTERNAL_SERVER_ERROR, ErrorMessage.INTERNAL_SERVER_ERROR.getMessage(), null));

--- a/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
@@ -9,7 +9,10 @@ public enum SuccessMessage {
     WRITE_SUCCESS("저장에 성공하였습니다."),
     READ_SUCCESS("조회에 성공하였습니다."),
     UPDATE_SUCCESS("수정에 성공하였습니다."),
-    DELETE_SUCCESS("삭제에 성공하였습니다.");
+    DELETE_SUCCESS("삭제에 성공하였습니다."),
+
+    LOGIN_SUCCESS("로그인에 성공하였습니다."),
+    CREATE_TOKENS("토큰발급에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/farmdora/farmdora/entity/Address.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Address.java
@@ -1,0 +1,25 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class Address {
+
+    private String addr;
+
+    private String addrDetail;
+
+    @Column(length = 5)
+    private String zipCode;
+}

--- a/src/main/java/com/farmdora/farmdora/entity/BaseTimeEntity.java
+++ b/src/main/java/com/farmdora/farmdora/entity/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Cart.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Cart.java
@@ -1,0 +1,45 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Entity
+@Table(
+        uniqueConstraints = {@UniqueConstraint(name = "uk_cart_user_option", columnNames = {"user_id, option_id"})}
+)
+public class Cart extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_id")
+    private Option option;
+
+    private Integer quantity;
+
+}
+

--- a/src/main/java/com/farmdora/farmdora/entity/Category.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Category.java
@@ -1,0 +1,36 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_category_name", columnNames = {"name"})
+        }
+)
+public class Category extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 120, unique = true)
+    private String name;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/DeliveryAddress.java
+++ b/src/main/java/com/farmdora/farmdora/entity/DeliveryAddress.java
@@ -1,0 +1,50 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class DeliveryAddress extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(length = 40)
+    private String addressLabel;
+
+    @Column(length = 60)
+    private String receiverName;
+
+    @Column(length = 30)
+    private String phone;
+
+    @Embedded
+    private Address address;
+
+    private String note;
+
+    private boolean isDefault = false;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Gender.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Gender.java
@@ -1,0 +1,5 @@
+package com.farmdora.farmdora.entity;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Image.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Image.java
@@ -1,0 +1,24 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class Image {
+
+    private String originalName;
+
+    @Column(length = 500)
+    private String imageUrl;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Like.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Like.java
@@ -1,0 +1,43 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Entity
+@Table(
+        name = "`like`",
+        uniqueConstraints = {@UniqueConstraint(name = "uk_like_user_option", columnNames = {"user_id, option_id"})}
+)
+public class Like extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_id")
+    private Option option;
+
+}
+

--- a/src/main/java/com/farmdora/farmdora/entity/Option.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Option.java
@@ -1,0 +1,46 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "`option`")
+public class Option extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Column(length = 150)
+    private String name;
+
+    private int price;
+
+    private int stock;
+
+    private boolean isActive = true;
+
+    private boolean isDeleted = false;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Order.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Order.java
@@ -1,0 +1,43 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "`order`")
+public class Order extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "delivery_address_id")
+    private DeliveryAddress deliveryAddress;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus status;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/OrderOption.java
+++ b/src/main/java/com/farmdora/farmdora/entity/OrderOption.java
@@ -1,0 +1,40 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderOption extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_id")
+    private Option option;
+
+    private Integer quantity;
+
+    private Integer price;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/OrderStatus.java
+++ b/src/main/java/com/farmdora/farmdora/entity/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.farmdora.farmdora.entity;
+
+public enum OrderStatus {
+    ORDER_COMPLETED, PREPARING, IN_TRANSIT, DELIVERED, CANCELLED
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Pay.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Pay.java
@@ -1,0 +1,47 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Pay extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @Enumerated(EnumType.STRING)
+    private PayStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private PayMethod method;
+
+    private String pgTid;
+
+    private LocalDateTime approvedAt;
+
+    private String failedReason;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/PayMethod.java
+++ b/src/main/java/com/farmdora/farmdora/entity/PayMethod.java
@@ -1,0 +1,5 @@
+package com.farmdora.farmdora.entity;
+
+public enum PayMethod {
+    CARD, BANK, TRANSFER
+}

--- a/src/main/java/com/farmdora/farmdora/entity/PayStatus.java
+++ b/src/main/java/com/farmdora/farmdora/entity/PayStatus.java
@@ -1,0 +1,5 @@
+package com.farmdora.farmdora.entity;
+
+public enum PayStatus {
+    READY, CANCELLED, PAID, FAILED
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Product.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Product.java
@@ -1,0 +1,50 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Product extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sub_category_id")
+    private SubCategory subCategory;
+
+    @Column(length = 200)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(length = 50)
+    private String origin;
+
+    private boolean isDisplay = true;
+
+    private boolean isDeleted = false;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/ProductImage.java
+++ b/src/main/java/com/farmdora/farmdora/entity/ProductImage.java
@@ -1,0 +1,38 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class ProductImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Embedded
+    private Image image;
+
+    private boolean isMain = false;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Question.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Question.java
@@ -1,0 +1,48 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Question extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Column(length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(columnDefinition = "TEXT")
+    private String answer;
+
+    private boolean isBlind = false;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Refund.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Refund.java
@@ -1,0 +1,44 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Refund extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_option_id")
+    private OrderOption orderOption;
+
+    @Enumerated(EnumType.STRING)
+    private RefundType type;
+
+    private String reason;
+
+    private Integer amount;
+
+    @Enumerated(EnumType.STRING)
+    private RefundStatus status = RefundStatus.REQUESTED;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/RefundImage.java
+++ b/src/main/java/com/farmdora/farmdora/entity/RefundImage.java
@@ -1,0 +1,36 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class RefundImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "refund_id")
+    private Refund refund;
+
+    @Embedded
+    private Image image;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/RefundStatus.java
+++ b/src/main/java/com/farmdora/farmdora/entity/RefundStatus.java
@@ -1,0 +1,5 @@
+package com.farmdora.farmdora.entity;
+
+public enum RefundStatus {
+    REQUESTED, APPROVED, REJECTED, COMPLETED
+}

--- a/src/main/java/com/farmdora/farmdora/entity/RefundType.java
+++ b/src/main/java/com/farmdora/farmdora/entity/RefundType.java
@@ -1,0 +1,5 @@
+package com.farmdora.farmdora.entity;
+
+public enum RefundType {
+    CHANGE, REFUND
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Review.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Review.java
@@ -1,0 +1,56 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(
+        uniqueConstraints = {@UniqueConstraint(name = "uk_review_once", columnNames = {"order_option_id"})}
+)
+public class Review extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_option_id")
+    private OrderOption orderOption;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(columnDefinition = "TEXT")
+    private String reply;
+
+    @Column(precision = 2, scale = 1)
+    private BigDecimal score;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/ReviewImage.java
+++ b/src/main/java/com/farmdora/farmdora/entity/ReviewImage.java
@@ -1,0 +1,36 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class ReviewImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @Embedded
+    private Image image;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Role.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Role.java
@@ -1,0 +1,5 @@
+package com.farmdora.farmdora.entity;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Sns.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Sns.java
@@ -1,0 +1,37 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Sns {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sns_type_id")
+    private SnsType type;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/SnsType.java
+++ b/src/main/java/com/farmdora/farmdora/entity/SnsType.java
@@ -1,0 +1,35 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(
+    uniqueConstraints = {
+            @UniqueConstraint(name = "uk_sns_type_name", columnNames = {"name"})
+    }
+)
+public class SnsType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 30, unique = true)
+    private String name;
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Store.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Store.java
@@ -1,0 +1,48 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Store extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(length = 120)
+    private String name;
+
+    @Column(length = 30)
+    private String businessNumber;
+
+    @Column(length = 30)
+    private String phone;
+
+    @Embedded
+    private Address address;
+
+    private boolean isApprove = false;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/SubCategory.java
+++ b/src/main/java/com/farmdora/farmdora/entity/SubCategory.java
@@ -1,0 +1,43 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_sub_category_name", columnNames = {"category_id, name"})
+        }
+)
+public class SubCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Column(length = 120, unique = true)
+    private String name;
+
+}

--- a/src/main/java/com/farmdora/farmdora/entity/User.java
+++ b/src/main/java/com/farmdora/farmdora/entity/User.java
@@ -1,0 +1,68 @@
+package com.farmdora.farmdora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(
+        name = "`user`",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_user_login", columnNames = {"username"}),
+                @UniqueConstraint(name = "uk_user_email", columnNames = {"email"})
+        }
+)
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 60)
+    private String username;
+
+    private String password;
+
+    @Column(length = 60)
+    private String name;
+
+    @Column(length = 120)
+    private String email;
+
+    @Embedded
+    private Address address;
+
+    private LocalDate birth;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Column(length = 30)
+    private String phone;
+
+    private boolean isExpire = false;
+
+    private boolean isBlind = false;
+
+    @Enumerated(EnumType.STRING)
+    private Role role = Role.USER;
+
+}

--- a/src/main/java/com/farmdora/farmdora/user/repository/UserRepository.java
+++ b/src/main/java/com/farmdora/farmdora/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.farmdora.farmdora.user.repository;
+
+import com.farmdora.farmdora.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+
+jwt:
+  secret: farmdora
+  expiration_time: 600000              # 10분
+  refresh_expiration_time: 1209600000  # 14일


### PR DESCRIPTION
## 👋 개요
관련 이슈: closes #7 #8 #9 

## 🧩 작업내용
- [x] 스프링 시큐리티 설정 추가
- [x] 회원가입, 로그인 API 추가
- [x] JWT 검증 필터 추가
- [x] 토큰 재발급 API 추가
- [x] 인증/인가 과정중 예외 처리

## 💡 특이사항
- 시큐리티 관련하여 노션의 '알고쓰자' 섹션에 정리해놓았습니다.
- 이전 PR에서 가져온 엔티티 클래스 부분은 빼고 리뷰해주세요.

## 📷 스크린샷

<img width="2524" height="3840" alt="Untitled diagram _ Mermaid Chart-2025-09-04-144203" src="https://github.com/user-attachments/assets/678fb7d9-7b71-4d83-9fbf-2b5da1504286" />

<img width="2596" height="3840" alt="Untitled diagram _ Mermaid Chart-2025-09-04-145908" src="https://github.com/user-attachments/assets/994ea308-5148-4c6d-ba64-eae3ce442a03" />

## 🧪 테스트
- [x] API 로컬 셀프 QA 완료

## ✅ 체크리스트(작성자)
- [x] PR 제목 컨벤션 준수 (`feat: ~`, `fix: ~` 등)
- [x] 셀프 리뷰/불필요한 코드 제거
