### PR TITLE
[CHORE] p6spy, jasypt 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'com.auth0:java-jwt:4.4.0'
+
+	// jasypt
+	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+	// p6spy
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/farmdora/farmdora/auth/config/SecurityConfig.java
+++ b/src/main/java/com/farmdora/farmdora/auth/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.farmdora.farmdora.auth.config;
 import com.farmdora.farmdora.auth.filter.CustomAccessDeniedHandler;
 import com.farmdora.farmdora.auth.filter.CustomAuthenticationEntrypoint;
 import com.farmdora.farmdora.auth.filter.JwtAuthorizationFilter;
-import com.farmdora.farmdora.auth.service.LoginService;
 import com.farmdora.farmdora.auth.util.JwtUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -35,8 +34,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public JwtAuthorizationFilter jwtAuthorizationFilter(JwtUtil jwtUtil, LoginService loginService) {
-        return new JwtAuthorizationFilter(jwtUtil, loginService);
+    public JwtAuthorizationFilter jwtAuthorizationFilter(JwtUtil jwtUtil) {
+        return new JwtAuthorizationFilter(jwtUtil);
     }
 
     @Bean

--- a/src/main/java/com/farmdora/farmdora/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/farmdora/farmdora/auth/filter/JwtAuthorizationFilter.java
@@ -2,7 +2,6 @@ package com.farmdora.farmdora.auth.filter;
 
 import com.farmdora.farmdora.auth.dto.JwtConstants;
 import com.farmdora.farmdora.auth.dto.LoginUser;
-import com.farmdora.farmdora.auth.service.LoginService;
 import com.farmdora.farmdora.auth.util.AuthenticationResponseUtil;
 import com.farmdora.farmdora.auth.util.JwtUtil;
 import com.farmdora.farmdora.common.error.exception.CustomException;
@@ -30,7 +29,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
-    private final LoginService loginService;
 
     // 아래 url들은 jwt 토큰 검사를 패스함
     private static final List<String> WHITELIST = List.of(
@@ -69,7 +67,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         try {
             if (StringUtils.hasText(token)) {
                 LoginUser principal = jwtUtil.verify(token);
-                principal = loginService.getLoginUser(principal.getId());
 
                 if (SecurityContextHolder.getContext().getAuthentication() == null) {
                     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/farmdora/farmdora/config/JasyptConfig.java
+++ b/src/main/java/com/farmdora/farmdora/config/JasyptConfig.java
@@ -1,0 +1,32 @@
+package com.farmdora.farmdora.config;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JasyptConfig {
+
+    @Value("${jasypt.encryptor.password}")
+    private String password;
+
+    @Bean("jasyptEncryptor")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(password);
+        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setKeyObtentionIterations("1000");
+        config.setPoolSize("1");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator");
+        config.setStringOutputType("base64");
+        encryptor.setConfig(config);
+
+        return encryptor;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/config/P6spyConfig.java
+++ b/src/main/java/com/farmdora/farmdora/config/P6spyConfig.java
@@ -1,0 +1,15 @@
+package com.farmdora.farmdora.config;
+
+import com.p6spy.engine.spy.P6SpyOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class P6spyConfig {
+
+    @PostConstruct
+    public void setLogMessageFormat() {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(P6spyPrettySqlFormatter.class.getName());
+    }
+
+}

--- a/src/main/java/com/farmdora/farmdora/config/P6spyPrettySqlFormatter.java
+++ b/src/main/java/com/farmdora/farmdora/config/P6spyPrettySqlFormatter.java
@@ -1,0 +1,38 @@
+package com.farmdora.farmdora.config;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+
+public class P6spyPrettySqlFormatter implements MessageFormattingStrategy {
+
+    @Override
+    public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url) {
+        sql = formatSql(category, sql);
+
+        Date currentDate = new Date();
+
+        SimpleDateFormat format1 = new SimpleDateFormat("yy.MM.dd HH:mm:ss");
+
+        return format1.format(currentDate) + " | "+ "OperationTime : "+ elapsed + "ms" + sql;
+    }
+
+    private String formatSql(String category,String sql) {
+        if(sql ==null || sql.trim().equals("")) return sql;
+
+        if (Category.STATEMENT.getName().equals(category)) {
+            String tmpsql = sql.trim().toLowerCase(Locale.ROOT);
+            if(tmpsql.startsWith("create") || tmpsql.startsWith("alter") || tmpsql.startsWith("comment")) {
+                sql = FormatStyle.DDL.getFormatter().format(sql);
+            }else {
+                sql = FormatStyle.BASIC.getFormatter().format(sql);
+            }
+            sql = "|\nHeFormatSql(P6Spy sql,Hibernate format):"+ sql;
+        }
+
+        return sql;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,8 @@ jwt:
   secret: farmdora
   expiration_time: 600000              # 10분
   refresh_expiration_time: 1209600000  # 14일
+
+jasypt:
+  encryptor:
+    password: ${jasypt_key}
+    bean: jasyptEncryptor


### PR DESCRIPTION
## 👋 개요
관련 이슈: closes #12 

## 🧩 작업내용
- [x] jasypt 설정 추가
- [x] p6spy 설정 추가
- [x] 로그인 중 불필요한 로그 제거

## 💡 특이사항
```yaml
spring:
  datasource:
    driver-class-name: com.mysql.cj.jdbc.Driver
    url: jdbc:mysql://127.0.0.1:3306/farmdora
    username: root
    password: 1111

# 추가
decorator:
  datasource:
    p6spy:
      enable-logging: true
```
위와 같이 p6spy 활성화 설정을 추가해야 합니다. 이 설정은 로컬에서만 활성화해야 하므로 `application-local.yml`에 설정합니다.

**[결과화면]**
<img width="1536" height="269" alt="스크린샷 2025-09-05 오후 9 30 27" src="https://github.com/user-attachments/assets/5d4090fa-95fb-4c5b-828a-c5f6831b44d5" />
위와 같이 "?"가 아닌, 실제 인자 값이 들어간 쿼리를 로그로 확인할 수 있습니다. 
🚨 단, yaml에 `jpa.show-sql=true`를 설정하면 "?"를 포함한 로그가 한번 더 출려되므로 그 설정은 해주지 않습니다.

<br/>

**[jasypt 키 세팅]**
<img width="798" height="677" alt="스크린샷 2025-09-05 오후 9 33 12" src="https://github.com/user-attachments/assets/c1c39c4c-d419-4a9e-a38e-dc29b49b9813" />
Intelllij의 Edit Configurations에서 env 추가 후 키 값 추가

**[jasypt 암호화 방법]**
<img width="437" height="567" alt="스크린샷 2025-09-05 오후 9 35 11" src="https://github.com/user-attachments/assets/daded87e-3ebc-4ad6-b650-3ec287280856" />
아래 명시한 링크로 접속해 암호화 후 yaml에 `ENC()` 안에 작성합니다.

**[작성 예시]**
```yaml
spring:
  datasource:
    driver-class-name: com.mysql.cj.jdbc.Driver
    url: ENC(iF+h5RBsEmlddTmuQtCbRxXS/Tv4diYmxEGlHSw9BuYiOn9pQJ+x0Ba22/ER4wFK)  # 추가
    username: root
    password: 1111
```

## 🧪 테스트
- [x] API 로컬 셀프 QA 완료

## 🔗 참고자료
- https://www.devglan.com/online-tools/jasypt-online-encryption-decryption [jasypt 암호화 사이트]
- https://backtony.tistory.com/34 [p6spy 적용]

## ✅ 체크리스트(작성자)
- [x] PR 제목 컨벤션 준수 (`feat: ~`, `fix: ~` 등)
- [x] 셀프 리뷰/불필요한 코드 제거
